### PR TITLE
Avoid Django converting DOI to ASCII for MySQL

### DIFF
--- a/Scopus/db_loader.py
+++ b/Scopus/db_loader.py
@@ -85,7 +85,7 @@ def aggregate_records(item):
         db_source.save()
 
     documents.append(Document(eid=eid,
-                              doi=document['doi'],
+                              doi=smart_str(document['doi']),
                               group_id=document['group-id'],
                               title=smart_str(document['title']),
                               source=db_source,


### PR DESCRIPTION
The vast majority of errors (21 documents, and their associated abstracts, authorships and itemids) in the last load came from encoding errors in DOI. I think this might be sufficient to fix it. Can you please confirm, @nikzadb, if you believe this to be the case?